### PR TITLE
Reset counter in end_timer

### DIFF
--- a/data/cd_timer/functions/end_timer.mcfunction
+++ b/data/cd_timer/functions/end_timer.mcfunction
@@ -2,3 +2,4 @@
 
 schedule clear cd_timer:run_timer
 bossbar set cd_timer:cd_bar visible false
+scoreboard players set cdTimer cd_timer 0


### PR DESCRIPTION
Reset counter in end_timer so that it will start fresh if not manually reset.   Fixes problem where the counter pickups where it left off.